### PR TITLE
feat: implemented direct provider resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-13
+
+### Added
+
+- **Multi-provider API key support**: Configure separate API keys for different providers
+  - `CEREBRAS_API_KEY` / `cerebras-api-key` — direct Cerebras inference (fastest path)
+  - `OPENROUTER_API_KEY` / `openrouter-api-key` — OpenRouter multi-provider access
+  - `RAYPASTE_API_KEY` / `api-key` — reserved for future Raypaste backend
+- **Smart provider routing**: Automatically routes requests to the best available provider
+  - Cerebras models with a Cerebras key go direct (eliminates OpenRouter hop)
+  - Falls back to OpenRouter when no direct key is available
+  - Legacy `api_key` with `sk-or-` prefix is treated as OpenRouter key with migration notice
+- **Direct provider model IDs**: Models now carry a `DirectID` field for provider-native model identifiers (e.g., `llama-3.1-8b-instruct` for Cerebras direct vs `meta-llama/llama-3.1-8b-instruct` for OpenRouter)
+- **New config commands**: `raypaste config set cerebras-api-key` and `raypaste config set openrouter-api-key`
+- **Comprehensive tests**: Table-driven tests for `ResolveProviderKey`, `HasAnyAPIKey`, provider-specific getters, and `BuildRequest` with direct provider routing
+
+### Changed
+
+- **`NewClient` signature**: Now takes `(provider, apiKey)` instead of just `(apiKey)` — routes to the correct base URL and sets provider-appropriate headers
+- **`BuildRequest` signature**: Now takes a `provider` parameter to select the correct model ID (OpenRouter ID vs direct provider ID)
+- **API key validation**: `initConfig` now checks `HasAnyAPIKey()` instead of a single `GetAPIKey()`, with improved error messaging listing all key options
+- **Updated help text and documentation**: CLI help, README, and config command descriptions reflect the new multi-provider setup
+
 ## [0.3.1] - 2026-03-05
 
 ### Changed
@@ -229,6 +252,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Flexible Configuration**: Multiple configuration methods
 - **Model Flexibility**: Use built-in aliases or any OpenRouter model ID
 
+[0.4.0]: https://github.com/raypaste/raypaste-cli/releases/tag/v0.4.0
+[0.3.1]: https://github.com/raypaste/raypaste-cli/releases/tag/v0.3.1
 [0.3.0]: https://github.com/raypaste/raypaste-cli/releases/tag/v0.3.0
 [0.2.7]: https://github.com/raypaste/raypaste-cli/releases/tag/v0.2.7
 [0.2.2]: https://github.com/raypaste/raypaste-cli/releases/tag/v0.2.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,100 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Review this plan thoroughly before making any code changes. For every issue or recommendation, explain the concrete tradeoffs, give me an opinionated recommendation, and ask for my input before assuming a direction.
+
+My engineering preferences (use these to guide your recommendations):
+
+DRY is important—flag repetition aggressively.
+
+Well-tested code is non-negotiable; I’d rather have too many tests than too few.
+
+I want code that’s “engineered enough” — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity).
+
+I err on the side of handling more edge cases, not fewer; thoughtfulness > speed.
+
+Bias toward explicit over clever.
+
+1. Architecture review
+
+Evaluate:
+
+Overall system design and component boundaries.
+
+Dependency graph and coupling concerns.
+
+Data flow patterns and potential bottlenecks.
+
+Scaling characteristics and single points of failure.
+
+Security architecture (auth, data access, API boundaries).
+
+2. Code quality review
+
+Evaluate:
+
+Code organization and module structure.
+
+DRY violations—be aggressive here.
+
+Error handling patterns and missing edge cases (call these out explicitly).
+
+Technical debt hotspots.
+
+Areas that are over-engineered or under-engineered relative to my preferences.
+
+3. Test review
+
+Evaluate:
+
+Test coverage gaps (unit, integration, e2e).
+
+Test quality and assertion strength.
+
+Missing edge case coverage—be thorough.
+
+Untested failure modes and error paths.
+
+4. Performance review
+
+Evaluate:
+
+N+1 queries and database access patterns.
+
+Memory-usage concerns.
+
+Caching opportunities.
+
+Slow or high-complexity code paths.
+
+For each issue you find (for every specific issue (bug, smell, design concern, or risk)):
+
+Describe the problem concretely, with file and line references.
+
+Present 2–3 options, including “do nothing” where that’s reasonable.
+
+For each option, specify: implementation effort, risk, impact on other code, and maintenance burden.
+
+Give me your recommended option and why, mapped to my preferences above.
+
+Then explicitly ask whether I agree or want to choose a different direction before proceeding.
+
+Workflow and interaction
+
+Do not assume my priorities on timeline or scale.
+
+After each section, pause and ask for my feedback before moving on.
+
+BEFORE YOU START:
+
+Ask if I want one of two options:
+
+1/ BIG CHANGE: Work through this interactively, one section at a time (Architecture → Code Quality → Tests → Performance) with at most 4 top issues in each section.
+
+2/ SMALL CHANGE: Work through interactively ONE question per review section.
+
+FOR EACH STAGE OF REVIEW: output the explanation and pros and cons of each stage’s questions AND your opinionated recommendation and why, and then use AskUserQuestion. Also NUMBER issues and then give LETTERS for options and when using AskUserQuestion make sure each option clearly labels the issue NUMBER and option LETTER so the user doesn’t get confused. Make the recommended option always the 1st option.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Open-source ultra-fast AI completions right in your terminal.
 
-A lightning fast Go CLI for generating meta-prompts and AI completions quickly via [OpenRouter](https://openrouter.ai/), with fast model routing, configurable output lengths, customizable prompts, and an interactive mode.
+A lightning fast Go CLI for generating meta-prompts and AI completions quickly, with fast model routing, configurable output lengths, customizable prompts, and an interactive mode. Supports direct [Cerebras](https://www.cerebras.ai/) inference and multi-provider access via [OpenRouter](https://openrouter.ai/).
 
 - **Responses in Milliseconds**: Generate text completions in ~100-900ms using open-source models running on
   Cerebras chips.
@@ -10,7 +10,8 @@ A lightning fast Go CLI for generating meta-prompts and AI completions quickly v
 - **Project Context Awareness**: Automatically loads context from `CLAUDE.md`, `AGENTS.md`, or `.cursor/rules/` files to inform prompt generation
 - **Custom Prompts**: Create and use your own prompts
 - **Flexible Configuration**: Configure via YAML, environment variables, or CLI flags
-- **OpenRouter Integration**: Raypaste can be used with many different LLM providers and models through OpenRouter's API
+- **Direct Provider Access**: Connect directly to Cerebras for the fastest possible inference, or use OpenRouter for multi-provider access
+- **OpenRouter Integration**: Raypaste can also be used with many different LLM providers and models through OpenRouter's API
 
 ## Installation
 
@@ -45,33 +46,42 @@ sudo mv raypaste /usr/local/bin/
 
 ## Quick Start
 
-1. **Get an OpenRouter API key** from [openrouter.ai/keys](https://openrouter.ai/keys)
+1. **Get an API key** (choose one or both):
 
-   1a. (Recommended): Get a **Cerebras** key from [cerebras.ai](https://www.cerebras.ai) to set up in _OpenRouter > Settings > BYOK (bring your own key) > Cerebras API key_.
+   - **Cerebras (Recommended for speed)**: Get a key from [cloud.cerebras.ai](https://cloud.cerebras.ai/) for direct, ultra-fast inference
+   - **OpenRouter (Multi-provider)**: Get a key from [openrouter.ai/keys](https://openrouter.ai/keys) for access to many providers/models
 
-2. **Set your API key for Raypaste** (choose one method):
+2. **Set your API key(s)** (choose one method):
 
    **Option A: Config Command (Recommended)**
 
    ```bash
-   raypaste config set api-key <your_api_key_here>
+   # For direct Cerebras access (fastest)
+   raypaste config set cerebras-api-key <your_cerebras_key>
+
+   # For OpenRouter multi-provider access
+   raypaste config set openrouter-api-key <your_openrouter_key>
+
+   # You can set both — Cerebras models will go direct, others via OpenRouter
    ```
 
-   **Option B: Environment Variable**
+   **Option B: Environment Variables**
 
    ```bash
-   export RAYPASTE_API_KEY=your_api_key_here
+   export CEREBRAS_API_KEY=your_cerebras_key
+   # and/or
+   export OPENROUTER_API_KEY=your_openrouter_key
    ```
 
    To make it permanent, add to your shell config:
 
    ```bash
    # For zsh (macOS default)
-   echo 'export RAYPASTE_API_KEY=your_api_key_here' >> ~/.zshrc
+   echo 'export CEREBRAS_API_KEY=your_cerebras_key' >> ~/.zshrc
    source ~/.zshrc
 
    # For bash
-   echo 'export RAYPASTE_API_KEY=your_api_key_here' >> ~/.bashrc
+   echo 'export CEREBRAS_API_KEY=your_cerebras_key' >> ~/.bashrc
    source ~/.bashrc
    ```
 
@@ -80,11 +90,16 @@ sudo mv raypaste /usr/local/bin/
    ```bash
    mkdir -p ~/.raypaste
    cp config.yaml.example ~/.raypaste/config.yaml
-   # Edit ~/.raypaste/config.yaml and add your API key
+   # Edit ~/.raypaste/config.yaml and add your API key(s)
    nano ~/.raypaste/config.yaml
    ```
 
    **Note**: The `.env` file in the project directory is for reference only. Go programs don't automatically load `.env` files. You must either export the environment variable or use the config file at `~/.raypaste/config.yaml`.
+
+   **API Key Resolution**: When you select a model, raypaste picks the best available route:
+   1. If the model's provider has a direct key (e.g., Cerebras model + `CEREBRAS_API_KEY`), it goes direct
+   2. Otherwise, it falls back to OpenRouter if `OPENROUTER_API_KEY` is set
+   3. Legacy `RAYPASTE_API_KEY` / `api-key` with an `sk-or-` prefix is treated as an OpenRouter key (with a migration notice)
 
 3. **Generate your first prompt**:
 
@@ -127,15 +142,19 @@ raypaste "optimize this code" -m cerebras-gpt-oss-120b
 Manage configuration settings via the CLI:
 
 ```bash
-# Set values
-raypaste config set api-key sk-or-v1-...
+# Set API keys
+raypaste config set cerebras-api-key csk-...       # Direct Cerebras access
+raypaste config set openrouter-api-key sk-or-v1-... # OpenRouter access
+
+# Set other values
 raypaste config set default-model cerebras-llama-8b
 raypaste config set default-length short
 raypaste config set disable-copy true
 raypaste config set temperature 0.8
 
 # Get current values
-raypaste config get api-key
+raypaste config get cerebras-api-key
+raypaste config get openrouter-api-key
 raypaste config get default-model
 raypaste config get default-length
 
@@ -148,13 +167,15 @@ raypaste config prompt remove my-prompt          # Remove a custom prompt
 
 **Available config keys:**
 
-| Key              | Description                                         | Type    |
-| ---------------- | --------------------------------------------------- | ------- |
-| `api-key`        | OpenRouter API key                                  | string  |
-| `default-model`  | Default model alias or OpenRouter ID                | string  |
-| `default-length` | Default output length: `short`, `medium`, or `long` | string  |
-| `disable-copy`   | Disable auto-copy to clipboard                      | boolean |
-| `temperature`    | Sampling temperature (0.0 to 2.0)                   | float   |
+| Key                  | Description                                         | Type    |
+| -------------------- | --------------------------------------------------- | ------- |
+| `openrouter-api-key` | OpenRouter API key                                  | string  |
+| `cerebras-api-key`   | Cerebras API key (direct provider access)           | string  |
+| `api-key`            | Raypaste API key (reserved for future backend)      | string  |
+| `default-model`      | Default model alias or OpenRouter ID                | string  |
+| `default-length`     | Default output length: `short`, `medium`, or `long` | string  |
+| `disable-copy`       | Disable auto-copy to clipboard                      | boolean |
+| `temperature`        | Sampling temperature (0.0 to 2.0)                   | float   |
 
 **Config prompt command:**
 
@@ -212,7 +233,7 @@ Configuration is loaded in the following order (later sources override earlier o
 
 1. Default values
 2. Config file (`~/.raypaste/config.yaml`)
-3. Environment variables (`RAYPASTE_*`)
+3. Environment variables (`OPENROUTER_API_KEY`, `CEREBRAS_API_KEY`, `RAYPASTE_*`)
 4. CLI flags
 
 ### Config Command
@@ -220,8 +241,9 @@ Configuration is loaded in the following order (later sources override earlier o
 The easiest way to manage configuration is via the `config` command:
 
 ```bash
-# Set your API key
-raypaste config set api-key sk-or-v1-...
+# Set your API key(s)
+raypaste config set cerebras-api-key csk-...
+raypaste config set openrouter-api-key sk-or-v1-...
 
 # Set default model
 raypaste config set default-model cerebras-llama-8b
@@ -230,7 +252,7 @@ raypaste config set default-model cerebras-llama-8b
 raypaste config set default-length medium
 
 # View current settings
-raypaste config get api-key
+raypaste config get cerebras-api-key
 raypaste config get default-model
 ```
 
@@ -515,22 +537,32 @@ cat requirements.txt | raypaste "analyze these dependencies" -l medium
 ### API Key Not Found
 
 ```
-Error: API key not found. Set RAYPASTE_API_KEY environment variable or add to config.yaml
+Error: No API key configured. Set one of:
+  CEREBRAS_API_KEY    - for direct Cerebras inference
+  OPENROUTER_API_KEY  - for OpenRouter multi-provider access
+  Or run: raypaste config set cerebras-api-key <key>
 ```
 
-**Solution**: The CLI looks for your API key in two places:
+**Solution**: The CLI looks for API keys in these places:
 
-1. **Environment Variable**: `RAYPASTE_API_KEY` must be exported in your current shell session
+1. **Environment Variables**: `CEREBRAS_API_KEY` and/or `OPENROUTER_API_KEY`
 
    ```bash
-   export RAYPASTE_API_KEY=your_api_key_here
+   export CEREBRAS_API_KEY=your_cerebras_key
+   # or
+   export OPENROUTER_API_KEY=your_openrouter_key
    ```
 
-2. **Config File**: `~/.raypaste/config.yaml` (note: this is in your home directory, not the project directory)
+2. **Config Command** (recommended):
+
    ```bash
-   mkdir -p ~/.raypaste
-   cp config.yaml.example ~/.raypaste/config.yaml
-   # Edit the file and add your API key
+   raypaste config set cerebras-api-key your_key
+   ```
+
+3. **Config File**: `~/.raypaste/config.yaml` (note: this is in your home directory, not the project directory)
+   ```yaml
+   cerebras_api_key: "your_key"
+   openrouter_api_key: "your_key"
    ```
 
 **Common Issues**:
@@ -539,6 +571,7 @@ Error: API key not found. Set RAYPASTE_API_KEY environment variable or add to co
 - Having `config.yaml` in the project directory won't work - the CLI looks in `~/.raypaste/config.yaml`
 - Setting the variable without `export` won't work - it must be exported to be visible to the program
 - You don't need to rebuild the executable after setting the API key
+- If you previously used `RAYPASTE_API_KEY` with an OpenRouter key (`sk-or-*` prefix), it will still work but you'll see a migration notice
 
 ### Clipboard Not Working
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -24,11 +24,13 @@ This command allows you to view and modify configuration values.
 Configuration is stored in ~/.raypaste/config.yaml.
 
 ` + output.Bold("Available config keys:") + `
-  ` + output.Green("api-key") + `        - OpenRouter API key
-  ` + output.Green("default-model") + `  - Default model alias or OpenRouter ID
-  ` + output.Green("default-length") + ` - Default output length (short|medium|long)
-  ` + output.Green("disable-copy") + `   - Disable auto-copy to clipboard (true|false)
-  ` + output.Green("temperature") + `    - Sampling temperature (0.0-2.0)
+  ` + output.Green("openrouter-api-key") + ` - OpenRouter API key
+  ` + output.Green("cerebras-api-key") + `   - Cerebras API key (direct provider access)
+  ` + output.Green("api-key") + `            - Raypaste API key (reserved for future backend)
+  ` + output.Green("default-model") + `      - Default model alias or OpenRouter ID
+  ` + output.Green("default-length") + `     - Default output length (short|medium|long)
+  ` + output.Green("disable-copy") + `       - Disable auto-copy to clipboard (true|false)
+  ` + output.Green("temperature") + `        - Sampling temperature (0.0-2.0)
 
 ` + output.Bold("Config subcommands:") + `
   ` + output.Green("set [key] [value]") + `     - Set a configuration value
@@ -36,7 +38,8 @@ Configuration is stored in ~/.raypaste/config.yaml.
   ` + output.Green("prompt") + `               - Manage custom prompt templates
 
 ` + output.Bold("Examples:") + `
-  raypaste config set api-key sk-or-v1-...
+  raypaste config set openrouter-api-key sk-or-v1-...
+  raypaste config set cerebras-api-key csk-...
   raypaste config set default-model cerebras-llama-8b
   raypaste config set default-length short
   raypaste config set disable-copy true
@@ -65,6 +68,20 @@ var configSetCmd = &cobra.Command{
 		}
 
 		switch key {
+		case "openrouter-api-key":
+			cfg.OpenRouterAPIKey = value
+			if err := cfg.SaveTo(cfgFile); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, output.Green("✓")+" OpenRouter API key saved to config")
+
+		case "cerebras-api-key":
+			cfg.CerebrasAPIKey = value
+			if err := cfg.SaveTo(cfgFile); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, output.Green("✓")+" Cerebras API key saved to config")
+
 		case "api-key":
 			cfg.APIKey = value
 			if err := cfg.SaveTo(cfgFile); err != nil {
@@ -120,7 +137,7 @@ var configSetCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "%s Temperature set to %s\n", output.Green("✓"), output.Cyan(value))
 
 		default:
-			return fmt.Errorf("unknown config key: %s\nAvailable keys: api-key, default-model, default-length, disable-copy, temperature", key)
+			return fmt.Errorf("unknown config key: %s\nAvailable keys: openrouter-api-key, cerebras-api-key, api-key, default-model, default-length, disable-copy, temperature", key)
 		}
 
 		return nil
@@ -143,6 +160,28 @@ var configGetCmd = &cobra.Command{
 		}
 
 		switch key {
+		case "openrouter-api-key":
+			if key := cfg.GetOpenRouterAPIKey(); key != "" {
+				if cfg.OpenRouterAPIKey != "" {
+					fmt.Println(key)
+				} else {
+					fmt.Println(key + " (from environment)")
+				}
+			} else {
+				fmt.Println("not set")
+			}
+
+		case "cerebras-api-key":
+			if key := cfg.GetCerebrasAPIKey(); key != "" {
+				if cfg.CerebrasAPIKey != "" {
+					fmt.Println(key)
+				} else {
+					fmt.Println(key + " (from environment)")
+				}
+			} else {
+				fmt.Println("not set")
+			}
+
 		case "api-key":
 			if cfg.APIKey != "" {
 				fmt.Println(cfg.APIKey)
@@ -165,7 +204,7 @@ var configGetCmd = &cobra.Command{
 			fmt.Println(cfg.Temperature)
 
 		default:
-			return fmt.Errorf("unknown config key: %s\nAvailable keys: api-key, default-model, default-length, disable-copy, temperature", key)
+			return fmt.Errorf("unknown config key: %s\nAvailable keys: openrouter-api-key, cerebras-api-key, api-key, default-model, default-length, disable-copy, temperature", key)
 		}
 
 		return nil

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -144,6 +144,14 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
+// maskSecret returns a masked representation of a secret, showing only the last 4 characters.
+func maskSecret(s string) string {
+	if len(s) <= 4 {
+		return "****"
+	}
+	return strings.Repeat("*", len(s)-4) + s[len(s)-4:]
+}
+
 // configGetCmd represents the config get command
 var configGetCmd = &cobra.Command{
 	Use:   "get [key]",
@@ -162,10 +170,11 @@ var configGetCmd = &cobra.Command{
 		switch key {
 		case "openrouter-api-key":
 			if key := cfg.GetOpenRouterAPIKey(); key != "" {
+				masked := maskSecret(key)
 				if cfg.OpenRouterAPIKey != "" {
-					fmt.Println(key)
+					fmt.Println(masked)
 				} else {
-					fmt.Println(key + " (from environment)")
+					fmt.Println(masked + " (from environment)")
 				}
 			} else {
 				fmt.Println("not set")
@@ -173,10 +182,11 @@ var configGetCmd = &cobra.Command{
 
 		case "cerebras-api-key":
 			if key := cfg.GetCerebrasAPIKey(); key != "" {
+				masked := maskSecret(key)
 				if cfg.CerebrasAPIKey != "" {
-					fmt.Println(key)
+					fmt.Println(masked)
 				} else {
-					fmt.Println(key + " (from environment)")
+					fmt.Println(masked + " (from environment)")
 				}
 			} else {
 				fmt.Println("not set")
@@ -184,9 +194,9 @@ var configGetCmd = &cobra.Command{
 
 		case "api-key":
 			if cfg.APIKey != "" {
-				fmt.Println(cfg.APIKey)
+				fmt.Println(maskSecret(cfg.APIKey))
 			} else if envKey := os.Getenv("RAYPASTE_API_KEY"); envKey != "" {
-				fmt.Println(envKey + " (from environment)")
+				fmt.Println(maskSecret(envKey) + " (from environment)")
 			} else {
 				fmt.Println("not set")
 			}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -63,6 +63,13 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 		state.Model = cfg.GetDefaultModel()
 	}
 
+	// Resolve provider and API key for the chosen model
+	pk, err := cfg.ResolveProviderKey(state.Model)
+	if err != nil {
+		return err
+	}
+	state.Provider = pk.Provider
+
 	length, err := config.ValidateOutputLength(lengthFlag)
 	if err != nil {
 		return err
@@ -76,7 +83,7 @@ func runInteractive(cmd *cobra.Command, args []string) error {
 
 	workingDir, _ := os.Getwd()
 	state.ProjCtx = projectcontext.Load(workingDir)
-	state.Client = llm.NewClient(cfg.GetAPIKey())
+	state.Client = llm.NewClient(pk.Provider, pk.APIKey)
 
 	return interactive.Run(state, interactive.Options{
 		Temperature: cfg.Temperature,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,14 +43,16 @@ var rootCmd = &cobra.Command{
 	Short: output.Cyan("Generate ") + output.Bold("AI-optimized prompts") + output.Cyan(" from your input"),
 	Long: output.Bold("raypaste-cli") + output.Cyan(" - Ultra-fast AI revised meta prompts from your input text.") + `
 
-A Cobra-based CLI that generates meta-prompts and general AI completions via OpenRouter,
+A Cobra-based CLI that generates meta-prompts and general AI completions,
 with configurable output lengths and fast/small model routing.
+Supports direct Cerebras inference and OpenRouter for multi-provider access.
 
 ` + output.Bold("Setup:") + `
-  raypaste config set api-key ` + output.Green("sk-or-v1-...") + `        ` + output.Cyan("# Set your OpenRouter API key") + `
-  raypaste config set default-model ` + output.Green("cerebras-llama-8b") + `  ` + output.Cyan("# Set default model") + `
-  raypaste config ` + output.Green("get default-model") + `                     ` + output.Cyan("# View current settings") + `
-  raypaste config prompt ` + output.Green("add my-prompt") + `                 ` + output.Cyan("# Add a custom prompt") + `
+  raypaste config set cerebras-api-key ` + output.Green("csk-...") + `          ` + output.Cyan("# Direct Cerebras access") + `
+  raypaste config set openrouter-api-key ` + output.Green("sk-or-v1-...") + `   ` + output.Cyan("# OpenRouter access") + `
+  raypaste config set default-model ` + output.Green("cerebras-llama-8b") + `    ` + output.Cyan("# Set default model") + `
+  raypaste config ` + output.Green("get default-model") + `                       ` + output.Cyan("# View current settings") + `
+  raypaste config prompt ` + output.Green("add my-prompt") + `                   ` + output.Cyan("# Add a custom prompt") + `
 
 ` + output.Bold("Examples:") + `
   raypaste "help me write a blog post" ` + output.Green("--length short") + `
@@ -119,9 +121,12 @@ func initConfig() {
 		os.Exit(1)
 	}
 
-	// Validate API key
-	if cfg.GetAPIKey() == "" {
-		fmt.Fprintln(os.Stderr, "Error: API key not found. Set RAYPASTE_API_KEY environment variable or add to config.yaml")
+	// Validate that at least one API key is configured
+	if !cfg.HasAnyAPIKey() {
+		fmt.Fprintln(os.Stderr, "Error: No API key configured. Set one of:")
+		fmt.Fprintln(os.Stderr, "  CEREBRAS_API_KEY    - for direct Cerebras inference")
+		fmt.Fprintln(os.Stderr, "  OPENROUTER_API_KEY  - for OpenRouter multi-provider access")
+		fmt.Fprintln(os.Stderr, "  Or run: raypaste config set cerebras-api-key <key>")
 		os.Exit(1)
 	}
 }
@@ -165,6 +170,12 @@ func runGenerate(_ *cobra.Command, args []string) error {
 
 	maxTokensOverride := store.GetMaxTokensOverride(promptFlag, length)
 
+	// Resolve which provider and API key to use for this model
+	pk, err := cfg.ResolveProviderKey(model)
+	if err != nil {
+		return err
+	}
+
 	req, err := llm.BuildRequest(
 		model,
 		systemPrompt,
@@ -174,12 +185,13 @@ func runGenerate(_ *cobra.Command, args []string) error {
 		false, // no streaming for generate
 		cfg.Models,
 		maxTokensOverride,
+		pk.Provider,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
 	}
 
-	client := llm.NewClient(cfg.GetAPIKey())
+	client := llm.NewClient(pk.Provider, pk.APIKey)
 
 	// Show progress indicator
 	fmt.Fprintln(os.Stderr, output.GeneratingMessage(model, string(length), projCtx.Filename))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/raypaste/raypaste-cli/pkg/types"
 
@@ -15,13 +16,15 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	APIKey        string             `mapstructure:"api_key"`
-	DefaultModel  string             `mapstructure:"default_model"`
-	DefaultLength types.OutputLength `mapstructure:"default_length"`
-	AutoCopy      bool               `mapstructure:"auto_copy"`    // Deprecated: kept for backward compatibility
-	DisableCopy   bool               `mapstructure:"disable_copy"` // New field to disable clipboard copying
-	Models        map[string]Model   `mapstructure:"models"`
-	Temperature   float64            `mapstructure:"temperature"`
+	APIKey           string             `mapstructure:"api_key"`
+	OpenRouterAPIKey string             `mapstructure:"openrouter_api_key"`
+	CerebrasAPIKey   string             `mapstructure:"cerebras_api_key"`
+	DefaultModel     string             `mapstructure:"default_model"`
+	DefaultLength    types.OutputLength `mapstructure:"default_length"`
+	AutoCopy         bool               `mapstructure:"auto_copy"`    // Deprecated: kept for backward compatibility
+	DisableCopy      bool               `mapstructure:"disable_copy"` // New field to disable clipboard copying
+	Models           map[string]Model   `mapstructure:"models"`
+	Temperature      float64            `mapstructure:"temperature"`
 }
 
 var globalConfig *Config
@@ -71,6 +74,8 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	// Bind specific env vars
 	_ = v.BindEnv("api_key", "RAYPASTE_API_KEY")
+	_ = v.BindEnv("openrouter_api_key", "OPENROUTER_API_KEY")
+	_ = v.BindEnv("cerebras_api_key", "CEREBRAS_API_KEY")
 	_ = v.BindEnv("default_model", "RAYPASTE_DEFAULT_MODEL")
 	_ = v.BindEnv("default_length", "RAYPASTE_DEFAULT_LENGTH")
 	_ = v.BindEnv("disable_copy", "RAYPASTE_DISABLE_COPY")
@@ -124,6 +129,63 @@ func (c *Config) GetAPIKey() string {
 		return c.APIKey
 	}
 	return os.Getenv("RAYPASTE_API_KEY")
+}
+
+// ProviderKey holds the resolved provider name and API key for a request
+type ProviderKey struct {
+	Provider string
+	APIKey   string
+}
+
+// ResolveProviderKey determines which provider and API key to use for a given model.
+func (c *Config) ResolveProviderKey(modelAlias string) (ProviderKey, error) {
+	model, err := ResolveModel(modelAlias, c.Models)
+	if err != nil {
+		return ProviderKey{}, err
+	}
+
+	// 1. If model provider is "cerebras" and we have a Cerebras key, go direct
+	if model.Provider == "cerebras" {
+		if key := c.GetCerebrasAPIKey(); key != "" {
+			return ProviderKey{Provider: "cerebras", APIKey: key}, nil
+		}
+	}
+
+	// 2. If we have an OpenRouter key, route through OpenRouter
+	if key := c.GetOpenRouterAPIKey(); key != "" {
+		return ProviderKey{Provider: "openrouter", APIKey: key}, nil
+	}
+
+	// 3. Legacy fallback: treat api_key as OpenRouter if it looks like one
+	if key := c.GetAPIKey(); key != "" {
+		if strings.HasPrefix(key, "sk-or-") {
+			fmt.Fprintln(os.Stderr, "Warning: using api_key as OpenRouter key. Please run: raypaste config set openrouter-api-key "+key)
+			return ProviderKey{Provider: "openrouter", APIKey: key}, nil
+		}
+	}
+
+	return ProviderKey{}, fmt.Errorf("no API key configured for provider %q. Set OPENROUTER_API_KEY or CEREBRAS_API_KEY", model.Provider)
+}
+
+// GetOpenRouterAPIKey retrieves the OpenRouter API key from config or environment
+func (c *Config) GetOpenRouterAPIKey() string {
+	if c.OpenRouterAPIKey != "" {
+		return c.OpenRouterAPIKey
+	}
+	return os.Getenv("OPENROUTER_API_KEY")
+}
+
+// GetCerebrasAPIKey retrieves the Cerebras API key from config or environment
+func (c *Config) GetCerebrasAPIKey() string {
+	if c.CerebrasAPIKey != "" {
+		return c.CerebrasAPIKey
+	}
+	return os.Getenv("CEREBRAS_API_KEY")
+}
+
+// HasAnyAPIKey returns true if any API key is configured (provider-specific or legacy)
+func (c *Config) HasAnyAPIKey() bool {
+	return c.GetOpenRouterAPIKey() != "" || c.GetCerebrasAPIKey() != "" || c.GetAPIKey() != ""
 }
 
 // GetDefaultModel returns the default model setting
@@ -192,6 +254,8 @@ func (c *Config) SaveTo(path string) error {
 
 	// Set all current values
 	v.Set("api_key", c.APIKey)
+	v.Set("openrouter_api_key", c.OpenRouterAPIKey)
+	v.Set("cerebras_api_key", c.CerebrasAPIKey)
 	v.Set("default_model", c.DefaultModel)
 	v.Set("default_length", c.DefaultLength)
 	v.Set("disable_copy", c.DisableCopy)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,173 @@ func TestConfigGetAPIKey(t *testing.T) {
 	}
 }
 
+func TestResolveProviderKey(t *testing.T) {
+	// Clear env vars that could interfere
+	for _, env := range []string{"OPENROUTER_API_KEY", "CEREBRAS_API_KEY", "RAYPASTE_API_KEY"} {
+		t.Setenv(env, "")
+	}
+
+	tests := []struct {
+		name         string
+		cfg          Config
+		modelAlias   string
+		wantProvider string
+		wantKey      string
+		wantErr      bool
+	}{
+		{
+			name:         "cerebras model with cerebras key goes direct",
+			cfg:          Config{CerebrasAPIKey: "csk-123", Models: map[string]Model{}},
+			modelAlias:   "cerebras-llama-8b",
+			wantProvider: "cerebras",
+			wantKey:      "csk-123",
+		},
+		{
+			name:         "cerebras model with only openrouter key falls back to openrouter",
+			cfg:          Config{OpenRouterAPIKey: "sk-or-abc", Models: map[string]Model{}},
+			modelAlias:   "cerebras-llama-8b",
+			wantProvider: "openrouter",
+			wantKey:      "sk-or-abc",
+		},
+		{
+			name:         "cerebras model with both keys prefers direct",
+			cfg:          Config{CerebrasAPIKey: "csk-123", OpenRouterAPIKey: "sk-or-abc", Models: map[string]Model{}},
+			modelAlias:   "cerebras-llama-8b",
+			wantProvider: "cerebras",
+			wantKey:      "csk-123",
+		},
+		{
+			name:         "openai model with openrouter key uses openrouter",
+			cfg:          Config{OpenRouterAPIKey: "sk-or-abc", Models: map[string]Model{}},
+			modelAlias:   "openai-gpt5-nano",
+			wantProvider: "openrouter",
+			wantKey:      "sk-or-abc",
+		},
+		{
+			name:       "openai model with only cerebras key errors",
+			cfg:        Config{CerebrasAPIKey: "csk-123", Models: map[string]Model{}},
+			modelAlias: "openai-gpt5-nano",
+			wantErr:    true,
+		},
+		{
+			name:         "legacy api_key with sk-or prefix falls back to openrouter",
+			cfg:          Config{APIKey: "sk-or-legacy", Models: map[string]Model{}},
+			modelAlias:   "cerebras-llama-8b",
+			wantProvider: "openrouter",
+			wantKey:      "sk-or-legacy",
+		},
+		{
+			name:       "legacy api_key without sk-or prefix does not fall back",
+			cfg:        Config{APIKey: "some-other-key", Models: map[string]Model{}},
+			modelAlias: "cerebras-llama-8b",
+			wantErr:    true,
+		},
+		{
+			name:       "no keys configured errors",
+			cfg:        Config{Models: map[string]Model{}},
+			modelAlias: "cerebras-llama-8b",
+			wantErr:    true,
+		},
+		{
+			name:         "unknown provider model with openrouter key uses openrouter",
+			cfg:          Config{OpenRouterAPIKey: "sk-or-abc", Models: map[string]Model{}},
+			modelAlias:   "some-provider/some-model",
+			wantProvider: "openrouter",
+			wantKey:      "sk-or-abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pk, err := tt.cfg.ResolveProviderKey(tt.modelAlias)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveProviderKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if pk.Provider != tt.wantProvider {
+				t.Errorf("ResolveProviderKey() Provider = %q, want %q", pk.Provider, tt.wantProvider)
+			}
+			if pk.APIKey != tt.wantKey {
+				t.Errorf("ResolveProviderKey() APIKey = %q, want %q", pk.APIKey, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestHasAnyAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"no keys", Config{}, false},
+		{"openrouter key", Config{OpenRouterAPIKey: "sk-or-abc"}, true},
+		{"cerebras key", Config{CerebrasAPIKey: "csk-123"}, true},
+		{"legacy key", Config{APIKey: "some-key"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear env vars
+			for _, env := range []string{"OPENROUTER_API_KEY", "CEREBRAS_API_KEY", "RAYPASTE_API_KEY"} {
+				t.Setenv(env, "")
+			}
+			if got := tt.cfg.HasAnyAPIKey(); got != tt.want {
+				t.Errorf("HasAnyAPIKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetOpenRouterAPIKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		envKey string
+		want   string
+	}{
+		{"from config", Config{OpenRouterAPIKey: "config-key"}, "", "config-key"},
+		{"from env", Config{}, "env-key", "env-key"},
+		{"config priority", Config{OpenRouterAPIKey: "config-key"}, "env-key", "config-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OPENROUTER_API_KEY", tt.envKey)
+			got := tt.cfg.GetOpenRouterAPIKey()
+			if got != tt.want {
+				t.Errorf("GetOpenRouterAPIKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCerebrasAPIKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    Config
+		envKey string
+		want   string
+	}{
+		{"from config", Config{CerebrasAPIKey: "config-key"}, "", "config-key"},
+		{"from env", Config{}, "env-key", "env-key"},
+		{"config priority", Config{CerebrasAPIKey: "config-key"}, "env-key", "config-key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CEREBRAS_API_KEY", tt.envKey)
+			got := tt.cfg.GetCerebrasAPIKey()
+			if got != tt.want {
+				t.Errorf("GetCerebrasAPIKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfigGetDefaultModel(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/config/models.go
+++ b/internal/config/models.go
@@ -8,6 +8,7 @@ import "fmt"
 // Model represents an LLM model configuration
 type Model struct {
 	ID       string `yaml:"id" mapstructure:"id"`
+	DirectID string `yaml:"direct_id" mapstructure:"direct_id"`
 	Provider string `yaml:"provider" mapstructure:"provider"`
 	Tier     string `yaml:"tier" mapstructure:"tier"`
 }
@@ -16,11 +17,13 @@ type Model struct {
 var DefaultModels = map[string]Model{
 	"cerebras-llama-8b": {
 		ID:       "meta-llama/llama-3.1-8b-instruct",
+		DirectID: "llama-3.1-8b-instruct",
 		Provider: "cerebras",
 		Tier:     "fast",
 	},
 	"cerebras-gpt-oss-120b": {
 		ID:       "openai/gpt-oss-120b",
+		DirectID: "gpt-oss-120b",
 		Provider: "cerebras",
 		Tier:     "balanced",
 	},

--- a/internal/interactive/session.go
+++ b/internal/interactive/session.go
@@ -21,6 +21,7 @@ import (
 // State holds the REPL session state.
 type State struct {
 	Model        string
+	Provider     string // resolved provider name ("openrouter", "cerebras")
 	Length       types.OutputLength
 	PromptName   string
 	LastResponse string

--- a/internal/interactive/stream.go
+++ b/internal/interactive/stream.go
@@ -30,6 +30,7 @@ func generateStreaming(ctx context.Context, input string, state *State, opts Opt
 		true, // streaming enabled
 		opts.Models,
 		maxTokensOverride,
+		state.Provider,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -17,19 +17,29 @@ import (
 
 const (
 	openRouterBaseURL = "https://openrouter.ai/api/v1/chat/completions"
+	cerebrasBaseURL   = "https://api.cerebras.ai/v1/chat/completions"
 	defaultTimeout    = 30 * time.Second
 )
 
-// Client represents an OpenRouter API client
+// Client represents an LLM API client that routes to different providers
 type Client struct {
 	apiKey     string
+	baseURL    string
+	provider   string
 	httpClient *http.Client
 }
 
-// NewClient creates a new OpenRouter API client
-func NewClient(apiKey string) *Client {
+// NewClient creates a new LLM API client for the given provider
+func NewClient(provider, apiKey string) *Client {
+	baseURL := openRouterBaseURL
+	if provider == "cerebras" {
+		baseURL = cerebrasBaseURL
+	}
+
 	return &Client{
-		apiKey: apiKey,
+		apiKey:   apiKey,
+		baseURL:  baseURL,
+		provider: provider,
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
@@ -48,7 +58,7 @@ func (c *Client) Complete(ctx context.Context, req types.CompletionRequest) (str
 	}
 
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", openRouterBaseURL, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL, bytes.NewReader(body))
 	if err != nil {
 		return "", types.TokenUsage{}, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -106,7 +116,7 @@ func (c *Client) StreamComplete(ctx context.Context, req types.CompletionRequest
 	}
 
 	// Create HTTP request
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", openRouterBaseURL, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL, bytes.NewReader(body))
 	if err != nil {
 		return types.TokenUsage{}, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -155,12 +165,15 @@ func (c *Client) StreamComplete(ctx context.Context, req types.CompletionRequest
 	return processStreamingResponseWithUsage(resp.Body, callback)
 }
 
-// setHeaders sets the required headers for OpenRouter API
+// setHeaders sets the required headers based on the provider
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("HTTP-Referer", "https://github.com/raypaste/raypaste-cli")
-	req.Header.Set("X-Title", "raypaste-cli")
+
+	if c.provider == "openrouter" {
+		req.Header.Set("HTTP-Referer", "https://github.com/raypaste/raypaste-cli")
+		req.Header.Set("X-Title", "raypaste-cli")
+	}
 }
 
 // doWithRetry sends the request with simple retry logic

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -75,7 +75,7 @@ func TestGetBodySetForRetry(t *testing.T) {
 	defer server.Close()
 
 	// Create client with test server URL
-	client := NewClient("test-key")
+	client := NewClient("openrouter", "test-key")
 
 	// Create a request
 	req := types.CompletionRequest{
@@ -170,7 +170,7 @@ func TestRetryWithBodyRecreation(t *testing.T) {
 	defer server.Close()
 
 	// Create client with test server URL
-	client := NewClient("test-key")
+	client := NewClient("openrouter", "test-key")
 
 	// Create a request
 	req := types.CompletionRequest{

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -29,10 +29,21 @@ var LengthParams = map[types.OutputLength]types.LengthParams{
 
 // BuildRequest builds a completion request with the given parameters.
 // maxTokensOverride, if > 0, replaces the default max_tokens for the given length.
-func BuildRequest(modelAlias, systemPrompt, userPrompt string, length types.OutputLength, temperature float64, stream bool, customModels map[string]config.Model, maxTokensOverride int) (types.CompletionRequest, error) {
-	modelID, err := config.GetModelID(modelAlias, customModels)
+// provider determines which model ID to use: direct provider ID or OpenRouter ID.
+func BuildRequest(modelAlias, systemPrompt, userPrompt string, length types.OutputLength, temperature float64, stream bool, customModels map[string]config.Model, maxTokensOverride int, provider string) (types.CompletionRequest, error) {
+	model, err := config.ResolveModel(modelAlias, customModels)
 	if err != nil {
 		return types.CompletionRequest{}, fmt.Errorf("failed to resolve model: %w", err)
+	}
+
+	// Use DirectID when going straight to the provider, fall back to OpenRouter ID
+	modelID := model.ID
+	if provider != "openrouter" && model.DirectID != "" {
+		modelID = model.DirectID
+	}
+
+	if modelID == "" {
+		return types.CompletionRequest{}, fmt.Errorf("model %s has no ID for provider %s", modelAlias, provider)
 	}
 
 	lengthParams, ok := LengthParams[length]

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -81,6 +81,7 @@ func TestBuildRequest(t *testing.T) {
 				false,
 				customModels,
 				tt.maxTokensOverride,
+				"openrouter",
 			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildRequest() error = %v, wantErr %v", err, tt.wantErr)
@@ -102,6 +103,49 @@ func TestBuildRequest(t *testing.T) {
 				if len(req.Messages) != 2 {
 					t.Errorf("BuildRequest() Messages length = %v, want 2", len(req.Messages))
 				}
+			}
+		})
+	}
+}
+
+func TestBuildRequestDirectProvider(t *testing.T) {
+	customModels := map[string]config.Model{
+		"cerebras-test": {
+			ID:       "meta-llama/llama-3.1-8b-instruct",
+			DirectID: "llama-3.1-8b-instruct",
+			Provider: "cerebras",
+			Tier:     "fast",
+		},
+		"no-direct-id": {
+			ID:       "some/model",
+			Provider: "custom",
+			Tier:     "fast",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		alias     string
+		provider  string
+		wantModel string
+	}{
+		{"cerebras direct uses DirectID", "cerebras-test", "cerebras", "llama-3.1-8b-instruct"},
+		{"cerebras via openrouter uses ID", "cerebras-test", "openrouter", "meta-llama/llama-3.1-8b-instruct"},
+		{"no DirectID falls back to ID", "no-direct-id", "custom", "some/model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := BuildRequest(
+				tt.alias, "system", "user",
+				types.OutputLengthMedium, 0.7, false,
+				customModels, 0, tt.provider,
+			)
+			if err != nil {
+				t.Fatalf("BuildRequest() error = %v", err)
+			}
+			if req.Model != tt.wantModel {
+				t.Errorf("BuildRequest() Model = %q, want %q", req.Model, tt.wantModel)
 			}
 		})
 	}


### PR DESCRIPTION
## Background

Currently all LLM completions route through OpenRouter, requiring users to have an OpenRouter API key. Given the tight ties to Cerebras-provided inference for speed, we want to support direct Cerebras connections so users can bypass the OpenRouter hop for lower latency. This also lays groundwork for the future Raypaste backend, where RAYPASTE_API_KEY will authenticate against our own servers.

## Changes

  - Multi-provider API key support: Added OPENROUTER_API_KEY and CEREBRAS_API_KEY config fields and environment variable bindings. RAYPASTE_API_KEY / api-key is preserved but reserved for the future Raypaste backend.
  - Smart provider routing: New ResolveProviderKey() in internal/config/config.go picks the best route — direct Cerebras key preferred, OpenRouter fallback, legacy sk-or-* key migration with deprecation notice.
  - LLM client parameterization: NewClient() now takes (provider, apiKey), sets the correct base URL (api.cerebras.ai vs openrouter.ai) and provider-appropriate headers.
  - Direct model IDs: Added DirectID field to the Model struct so Cerebras models carry their provider-native ID (e.g.,
  llama-3.1-8b-instruct) alongside the OpenRouter ID (meta-llama/llama-3.1-8b-instruct). BuildRequest selects the right one based on provider.
  - Config CLI: Added openrouter-api-key and cerebras-api-key to config set / config get commands with updated help text.
  - Updated docs: README Quick Start, Config Command, Configuration, and Troubleshooting sections updated. CHANGELOG entry for v0.4.0

## Testing

  - All existing tests pass — updated NewClient and BuildRequest call signatures across client_test.go and router_test.go.
  - New TestResolveProviderKey: 9 table-driven cases covering: Cerebras direct, OpenRouter fallback, both keys set, OpenAI model with only Cerebras key (error), legacy sk-or-* migration, legacy key without prefix (error), no keys (error), unknown provider model.
  - New TestHasAnyAPIKey: 4 cases for each key source and no keys.
  - New TestGetOpenRouterAPIKey / TestGetCerebrasAPIKey: Config vs env var priority for each provider.
  - New TestBuildRequestDirectProvider: Verifies DirectID is used for direct provider routing and ID is used for OpenRouter
  - Linter: golangci-lint run ./...